### PR TITLE
Fix "Meeting" and "Note" template src blocks

### DIFF
--- a/GTD.org
+++ b/GTD.org
@@ -546,7 +546,7 @@ Now it is time to define a new capture template for registering a meeting.
 
 #+begin_src lisp
 ("m" "Meeting" entry  (file+headline "agenda.org" "Future")
- (concat "* %? :meeting:\n"
+ ,(concat "* %? :meeting:\n"
          "<%<%Y-%m-%d %a %H:00>>"))
 #+end_src
 
@@ -572,7 +572,7 @@ notes during a meeting:
 
 #+begin_src lisp
 ("n" "Note" entry  (file "notes.org")
- (concat "* Note (%a)\n"
+ ,(concat "* Note (%a)\n"
          "/Entered on/ %U\n" "\n" "%?"))
 #+end_src
 


### PR DESCRIPTION
Hi, I saw two smalls errors in the "Meeting" and "Note" template source blocks. I don't now if this was intentional but the ","  was missing in both source blocks and prevented copying and pasting these code snippets in the org-capture-templates list while following along the blog post. If this was intentional, feel free to close this pull request.

I also noticed the HTML version of this post is outdated and need to be rebuilt. Other typos have already been corrected in GTD.org but these changes are not reflected at https://www.labri.fr/perso/nrougier/GTD/index.html

Thanks for your work, it has been a few weeks since I discovered your work on nano-emacs and your other projects. When using everything together it really seems to be a cohesive whole and it's a real pleasure to work in this environment.